### PR TITLE
Add multivariate normal wasm library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/target
+mvn/pkg
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# mvn-rs
+
+Rust implementation of a multivariate normal distribution with WebAssembly bindings.
+
+## Building
+
+To build the Rust library normally:
+
+```bash
+cargo build
+```
+
+To build the WebAssembly package (requires `wasm-pack`):
+
+```bash
+wasm-pack build -t node --release -- --features wasm
+```
+
+This will generate an npm package in the `pkg` directory that can be published to npm.
+
+## Usage
+
+```rust
+use mvn::MultivariateNormal;
+
+let mean = vec![0.0, 0.0];
+let cov = vec![1.0, 0.0, 0.0, 1.0];
+let mvn = MultivariateNormal::new(mean, cov, 2);
+let sample = mvn.sample();
+```

--- a/mvn/Cargo.toml
+++ b/mvn/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "mvn"
+version = "0.1.0"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+description = "Multivariate normal distribution library with WASM support"
+repository = "https://example.com"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+nalgebra = "0.32"
+rand = "0.8"
+rand_distr = "0.4"
+wasm-bindgen = { version = "0.2", optional = true }
+
+[features]
+wasm = ["wasm-bindgen"]
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false

--- a/mvn/src/lib.rs
+++ b/mvn/src/lib.rs
@@ -1,0 +1,61 @@
+use nalgebra::{DMatrix, DVector};
+use rand::prelude::*;
+#[cfg(feature = "wasm")]
+use wasm_bindgen::prelude::*;
+
+/// Multivariate normal distribution
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+#[derive(Clone)]
+pub struct MultivariateNormal {
+    mean: DVector<f64>,
+    cov: DMatrix<f64>,
+    chol: DMatrix<f64>,
+}
+
+impl MultivariateNormal {
+    /// Create a new distribution with given mean vector and covariance matrix.
+    /// The covariance matrix must be positive definite.
+    #[cfg_attr(feature = "wasm", wasm_bindgen(constructor))]
+    pub fn new(mean: Vec<f64>, cov: Vec<f64>, dim: usize) -> Self {
+        let mean = DVector::from_vec(mean);
+        let cov = DMatrix::from_row_slice(dim, dim, &cov);
+        let chol = cov.cholesky().expect("Covariance not PD").l();
+        Self { mean, cov, chol }
+    }
+
+    /// Sample a random vector from the distribution.
+    #[cfg_attr(feature = "wasm", wasm_bindgen)]
+    pub fn sample(&self) -> Vec<f64> {
+        let mut rng = thread_rng();
+        let normal = rand_distr::StandardNormal;
+        let z: DVector<f64> = DVector::from_iterator(self.mean.len(), (0..self.mean.len()).map(|_| normal.sample(&mut rng)));
+        let sample = &self.mean + &self.chol * z;
+        sample.iter().cloned().collect()
+    }
+
+    /// Get the mean vector as a Vec.
+    #[cfg_attr(feature = "wasm", wasm_bindgen(getter))]
+    pub fn mean(&self) -> Vec<f64> {
+        self.mean.iter().cloned().collect()
+    }
+
+    /// Get the covariance matrix as a row-major Vec.
+    #[cfg_attr(feature = "wasm", wasm_bindgen(getter))]
+    pub fn covariance(&self) -> Vec<f64> {
+        self.cov.iter().cloned().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sample_dim() {
+        let mean = vec![0.0, 0.0];
+        let cov = vec![1.0, 0.0, 0.0, 1.0];
+        let mvn = MultivariateNormal::new(mean, cov, 2);
+        let sample = mvn.sample();
+        assert_eq!(sample.len(), 2);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "mvn-rs",
+  "version": "0.1.0",
+  "files": ["mvn/pkg"],
+  "scripts": {
+    "build": "wasm-pack build mvn -t node --release -- --features wasm"
+  },
+  "license": "MIT OR Apache-2.0"
+}


### PR DESCRIPTION
## Summary
- initialize project with multivariate normal distribution library
- add WASM and npm packaging support
- document build instructions

## Testing
- `cargo test --manifest-path mvn/Cargo.toml` *(fails: failed to download crates)*