### PR TITLE
Fix compile error in MultivariateNormal

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,18 @@
+name: Rust Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Run tests
+        run: cargo test --manifest-path mvn/Cargo.toml

--- a/mvn/src/lib.rs
+++ b/mvn/src/lib.rs
@@ -19,7 +19,8 @@ impl MultivariateNormal {
     pub fn new(mean: Vec<f64>, cov: Vec<f64>, dim: usize) -> Self {
         let mean = DVector::from_vec(mean);
         let cov = DMatrix::from_row_slice(dim, dim, &cov);
-        let chol = cov.cholesky().expect("Covariance not PD").l();
+        // cholesky consumes self, so operate on a clone to keep `cov` for the struct
+        let chol = cov.clone().cholesky().expect("Covariance not PD").l();
         Self { mean, cov, chol }
     }
 


### PR DESCRIPTION
## Summary
- fix ownership issue in `MultivariateNormal::new`
- workflow runs `cargo test` for mvn crate

## Testing
- `cargo test` *(fails: failed to download dependencies)*