### PR TITLE
Add JavaScript interface and benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,23 @@ let cov = vec![1.0, 0.0, 0.0, 1.0];
 let mvn = MultivariateNormal::new(mean, cov, 2);
 let sample = mvn.sample();
 ```
+
+## JavaScript Interface
+
+After building the WebAssembly package, you can access the distribution from Node.js:
+
+```javascript
+const mvn = require('./mvn/pkg');
+const dist = new mvn.MultivariateNormal([0, 0], [1, 0, 0, 1], 2);
+console.log(dist.sample());
+```
+
+## Benchmarks
+
+Simple performance benchmarks can be run with:
+
+```bash
+npm run benchmark
+```
+
+This compares the WebAssembly implementation with a pure JavaScript fallback located in `js/simple_mvn.js`.

--- a/benchmarks/benchmark.js
+++ b/benchmarks/benchmark.js
@@ -1,0 +1,21 @@
+const { performance } = require('perf_hooks');
+const wasm = require('../mvn/pkg');
+const { SimpleMultivariateNormal } = require('../js/simple_mvn');
+
+const dim = 2;
+const mean = [0, 0];
+const cov = [1, 0, 0, 1];
+
+const wasmMvn = new wasm.MultivariateNormal(mean, cov, dim);
+const jsMvn = new SimpleMultivariateNormal(mean, cov, dim);
+
+function bench(name, fn, iter) {
+  const start = performance.now();
+  for (let i = 0; i < iter; i++) fn();
+  const end = performance.now();
+  console.log(`${name}: ${(end - start).toFixed(2)} ms`);
+}
+
+const ITER = 10000;
+bench('wasm', () => wasmMvn.sample(), ITER);
+bench('js', () => jsMvn.sample(), ITER);

--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+const wasm = require('./mvn/pkg');
+module.exports = wasm;

--- a/js/simple_mvn.js
+++ b/js/simple_mvn.js
@@ -1,0 +1,48 @@
+function randn() {
+  let u = 0, v = 0;
+  while (u === 0) u = Math.random();
+  while (v === 0) v = Math.random();
+  return Math.sqrt(-2.0 * Math.log(u)) * Math.cos(2.0 * Math.PI * v);
+}
+
+function cholesky(cov, dim) {
+  const L = new Array(dim * dim).fill(0);
+  for (let i = 0; i < dim; i++) {
+    for (let j = 0; j <= i; j++) {
+      let sum = cov[i * dim + j];
+      for (let k = 0; k < j; k++) {
+        sum -= L[i * dim + k] * L[j * dim + k];
+      }
+      if (i === j) {
+        L[i * dim + j] = Math.sqrt(sum);
+      } else {
+        L[i * dim + j] = sum / L[j * dim + j];
+      }
+    }
+  }
+  return L;
+}
+
+class SimpleMultivariateNormal {
+  constructor(mean, cov, dim) {
+    this.mean = mean;
+    this.dim = dim;
+    this.chol = cholesky(cov, dim);
+  }
+
+  sample() {
+    const z = [];
+    for (let i = 0; i < this.dim; i++) z.push(randn());
+    const out = [];
+    for (let i = 0; i < this.dim; i++) {
+      let val = this.mean[i];
+      for (let j = 0; j <= i; j++) {
+        val += this.chol[i * this.dim + j] * z[j];
+      }
+      out[i] = val;
+    }
+    return out;
+  }
+}
+
+module.exports = { SimpleMultivariateNormal };

--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "name": "mvn-rs",
   "version": "0.1.0",
-  "files": ["mvn/pkg"],
+  "files": [
+    "mvn/pkg"
+  ],
   "scripts": {
-    "build": "wasm-pack build mvn -t node --release -- --features wasm"
+    "build": "wasm-pack build mvn -t node --release -- --features wasm",
+    "benchmark": "node benchmarks/benchmark.js"
   },
   "license": "MIT OR Apache-2.0"
 }


### PR DESCRIPTION
## Summary
- expose the WASM package via a simple `index.js`
- add a pure JavaScript implementation for comparison
- add benchmark script comparing WASM vs JS implementations
- document JS usage and benchmarking in README
- wire benchmark script into `package.json`

## Testing
- `npm run benchmark` *(fails: Cannot find module '../mvn/pkg')*
- `cargo test --manifest-path mvn/Cargo.toml` *(fails to fetch crates: could not connect to server)*